### PR TITLE
Robust filename reading

### DIFF
--- a/densevid_eval/para-evaluate.py
+++ b/densevid_eval/para-evaluate.py
@@ -88,7 +88,16 @@ class ANETcaptions(object):
         gts = []
         self.n_ref_vids = set()
         for filename in filenames:
-            gt = json.load(open(filename))
+            try:
+                gt = json.load(open(filename))
+            except:
+                try:
+                    gt = json.load(open(filename[:-1]))
+                except:
+                    try:
+                        gt = json.load(open(filename[1:-1]))
+                    except:
+                        gt = json.load(open(filename[1:]))
             self.n_ref_vids.update(gt.keys())
             gts.append(self.ensure_caption_key(gt))
         if self.verbose:


### PR DESCRIPTION
There are cases in which we have "," or "[" or "]" in the filename and we have to remove it.
I don't get why it works for you without this change. For me this change is required.

Maybe checking that the removed character is , or [ or ] would be better.